### PR TITLE
Fixing URL to WCAG HTML technique H35

### DIFF
--- a/src/lib/techniques.json
+++ b/src/lib/techniques.json
@@ -273,7 +273,7 @@
         }
       ],
       "related": ["G94"],
-      "url": "https://www.w3.org/WAI/WCAG21/Techniques/html/H25"
+      "url": "https://www.w3.org/WAI/WCAG21/Techniques/html/H35"
     }
   },
   "QW_WCAG_T12": {


### PR DESCRIPTION
Correcting a typo where the URL to w3.org ended with 'H25' instead of 'H35'.